### PR TITLE
Improve port specification

### DIFF
--- a/DFRobot_RaspberryPi_A02YYUW.py
+++ b/DFRobot_RaspberryPi_A02YYUW.py
@@ -36,11 +36,11 @@ class DFRobot_A02_Distance:
   distance_min = 0
   range_max = 4500
 
-  def __init__(self):
+  def __init__(self, port = '/dev/serial0'):
     '''
       @brief    Sensor initialization.
     '''
-    self._ser = serial.Serial("/dev/ttyAMA0", 9600)
+    self._ser = serial.Serial(port, 9600)
     if self._ser.isOpen() != True:
       self.last_operate_status = self.STA_ERR_SERIAL
 


### PR DESCRIPTION
Hello! I was having trouble getting this to work on my Pi Zero W because

```plain
OSError: [Errno 25] Inappropriate ioctl for device
```

After lots of looking around I found [a stackexchange answer](https://raspberrypi.stackexchange.com/a/99620) that said

> The port `/dev/ttyAMA0` may be connected to Bluetooth or serial, It is better practice to use `/dev/serial0` which is guaranteed to be the serial port (if enabled)

So my suggestion is (1) switching from `ttyAMA0` to `serial0` which probably takes care of most use cases and (2) giving the option to set a different port anyways. Thanks!